### PR TITLE
ci: silence slither `"unindexed-event-address"` incorrectly coming from a filtered-out path

### DIFF
--- a/contracts/slither.config.json
+++ b/contracts/slither.config.json
@@ -1,8 +1,8 @@
 {
-    "filter_paths": "dependencies/",
-    "detectors_to_exclude": [
-        "pragma",
-        "naming-convention",
-        "cyclomatic-complexity"
-    ]
+  "filter_paths": "dependencies/",
+  "detectors_to_exclude": [
+    "pragma",
+    "naming-convention",
+    "unindexed-event-address"
+  ]
 }


### PR DESCRIPTION
Ignore warning until https://github.com/crytic/slither/issues/2901 is resolved.