### PR TITLE
feat: add EmergencyCallExecuted event for traceability

### DIFF
--- a/contracts/src/ERC20Forwarder.sol
+++ b/contracts/src/ERC20Forwarder.sol
@@ -77,6 +77,11 @@ contract ERC20Forwarder is EmergencyMigratableForwarderBase {
     /// @param amount The token amount being withdrawn from the ERC20 forwarder contract.
     event Unwrapped(address indexed token, address indexed to, uint128 amount);
 
+    /// @notice Emitted when an emergency call is executed, before the actual wrap/unwrap operation.
+    /// @param caller The emergency caller executing the call.
+    /// @param inputHash The keccak256 hash of the input data for correlation with Wrapped/Unwrapped events.
+    event EmergencyCallExecuted(address indexed caller, bytes32 inputHash);
+
     error BalanceMismatch(uint256 expected, uint256 actual);
     error InvalidInputLength(uint256 expected, uint256 actual);
 
@@ -176,6 +181,7 @@ contract ERC20Forwarder is EmergencyMigratableForwarderBase {
     /// @return output The output of the emergency call.
     /// @dev This function internally uses the `SafeERC20` library.
     function _forwardEmergencyCall(bytes calldata input) internal override returns (bytes memory output) {
+        emit EmergencyCallExecuted({caller: msg.sender, inputHash: keccak256(input)});
         output = _forwardCall(input);
     }
 

--- a/contracts/test/ERC20ForwarderV2.t.sol
+++ b/contracts/test/ERC20ForwarderV2.t.sol
@@ -385,6 +385,11 @@ contract ERC20ForwarderV2Test is ERC20ForwarderTest {
         assertEq(_erc20.balanceOf(address(_fwdV2)), _TRANSFER_AMOUNT);
     }
 
+    /// @dev Skipped: V2 tests focus on migration, emergency event tested in ERC20ForwarderTest.
+    function test_forwardEmergencyCall_emits_the_EmergencyCallExecuted_event() public override {
+        vm.skip(true);
+    }
+
     function _deployContracts() internal returns (ProtocolAdapter paV1, ProtocolAdapter paV2, ERC20Forwarder fwdV1) {
         paV1 = new ProtocolAdapter(_router, _verifier.SELECTOR(), _EMERGENCY_COMMITTEE);
         paV2 = new ProtocolAdapter(_router, _verifier.SELECTOR(), _EMERGENCY_COMMITTEE);

--- a/contracts/test/ERC20ForwarderV3.t.sol
+++ b/contracts/test/ERC20ForwarderV3.t.sol
@@ -694,6 +694,11 @@ contract ERC20ForwarderV3Test is ERC20ForwarderTest {
         assertEq(_erc20.balanceOf(address(_fwdV3)), _TRANSFER_AMOUNT);
     }
 
+    /// @dev Skipped: V3 tests focus on migration, emergency event tested in ERC20ForwarderTest.
+    function test_forwardEmergencyCall_emits_the_EmergencyCallExecuted_event() public override {
+        vm.skip(true);
+    }
+
     function _deployContracts()
         internal
         returns (ProtocolAdapter paV1, ProtocolAdapter paV2, ProtocolAdapter paV3, ERC20Forwarder fwdV1)


### PR DESCRIPTION
This PR introduces an event before emergency calls to enable event-based monitoring and audit trails. I suggest this based on my last experience working on Anoma Explorer. Without the introduced event, you'd need to filter by caller address AND check which caller was the emergency caller at that point in time (it can change).

In conclusion, this change is useful and not critical whatsoever. Also, it is negligibly costly in gas terms, as emergency calls are rare. 
