### PR TITLE
Add record-deployment tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,6 +5020,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "record-deployment"
+version = "0.0.0"
+dependencies = [
+ "alloy-chains",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bindings"]
+members = ["bindings", "record-deployment"]
 
 [workspace.package]
 keywords = ["anoma", "evm", "protocol-adapter", "erc20", "forwarder"]

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -126,19 +126,19 @@ For each chain, you want to deploy to, do the following:
 
 ### 5. Update the Deployments Map and Create a new `contracts` and `bindings` GitHub Release
 
-- [ ] Add a deployment entry to [`./deployments.json`](./deployments.json) for each chain deployed. Example:
+- [ ] Record the deployment by running:
 
-  ```json
-  {
-    "network": "mainnet",
-    "chainId": 1,
-    "contractAddress": "0x...",
-    "version": "X.Y.Z",
-    "protocolAdapterAddress": "0x..."
-  }
+  ```sh
+  just record-deployment <CHAIN_NAME> <VERSION> <PROTOCOL_ADAPTER_ADDRESS>
   ```
 
-  The `protocolAdapterAddress` records which protocol adapter this forwarder is linked to. No extra tools or scripts are needed — the JSON is embedded at compile time by `addresses.rs`.
+  This reads the Foundry broadcast artifact, extracts the contract address, and updates `deployments.json`. No manual editing needed.
+
+  Alternatively, deploy and record in one step:
+
+  ```sh
+  just deploy-and-record deployer <TOKEN_TRANSFER_CIRCUIT_ID> <CHAIN_NAME> <PROTOCOL_ADAPTER_ADDRESS> <VERSION>
+  ```
 
 - [ ] Change the `bindings` package version number in the [`./bindings/Cargo.toml`](./bindings/Cargo.toml) file to `A.0.0`, where `A` is the last `MAJOR` version number incremented by 1.
 
@@ -285,19 +285,19 @@ For each **new** chain, you want to deploy to, do the following:
 
 ### 4. Update the Deployments Map and Create a new `bindings` GitHub Release
 
-- [ ] Add a deployment entry to [`./deployments.json`](./deployments.json) for each **new** chain deployed. Example:
+- [ ] Record each deployment by running:
 
-  ```json
-  {
-    "network": "base",
-    "chainId": 8453,
-    "contractAddress": "0x...",
-    "version": "X.Y.Z",
-    "protocolAdapterAddress": "0x..."
-  }
+  ```sh
+  just record-deployment <CHAIN_NAME> <VERSION> <PROTOCOL_ADAPTER_ADDRESS>
   ```
 
-  No extra tools or scripts are needed — the JSON is embedded at compile time by `addresses.rs`.
+  This reads the Foundry broadcast artifact, extracts the contract address, and updates `deployments.json`. No manual editing needed.
+
+  Alternatively, deploy and record in one step:
+
+  ```sh
+  just deploy-and-record deployer <TOKEN_TRANSFER_CIRCUIT_ID> <CHAIN_NAME> <PROTOCOL_ADAPTER_ADDRESS> <VERSION>
+  ```
 
 - [ ] Change the `bindings` package version number in the `./bindings/Cargo.toml` file to `A.B.0`, where `A` is the last `MAJOR` version and `B` is the last `MINOR` version number incremented by 1.
 

--- a/justfile
+++ b/justfile
@@ -90,6 +90,20 @@ bindings-check: contracts-gen-bindings
 bindings-publish *args:
     cd bindings && cargo publish {{ args }}
 
+# --- Record Deployment ---
+
+# Record deployment from broadcast artifact into deployments.json
+record-deployment chain version protocol-adapter:
+    cargo run -p record-deployment -- {{chain}} {{version}} {{protocol-adapter}}
+    @echo "==> Validating..."
+    @just bindings-build
+    @just bindings-test --test deployments
+
+# Deploy and record in one step
+deploy-and-record deployer token-transfer-circuit-id chain protocol-adapter version *args:
+    just contracts-deploy {{deployer}} {{token-transfer-circuit-id}} {{chain}} {{protocol-adapter}} {{args}}
+    just record-deployment {{chain}} {{version}} {{protocol-adapter}}
+
 # --- All ---
 
 # Build all (contracts + bindings)

--- a/record-deployment/Cargo.toml
+++ b/record-deployment/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+publish = false
+name = "record-deployment"
+version = "0.0.0"
+description = "Update deployments.json from Foundry broadcast artifacts."
+keywords.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+edition.workspace = true
+
+[dependencies]
+alloy-chains = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tempfile = "3"

--- a/record-deployment/src/main.rs
+++ b/record-deployment/src/main.rs
@@ -1,0 +1,124 @@
+use alloy_chains::NamedChain;
+use serde::{Deserialize, Serialize};
+use std::{env, fs, process};
+
+/// A single entry in deployments.json.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeploymentEntry {
+    network: String,
+    chain_id: u64,
+    contract_address: String,
+    version: String,
+    protocol_adapter_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<String>,
+}
+
+/// Minimal subset of Foundry's broadcast run-latest.json.
+#[derive(Deserialize)]
+struct BroadcastArtifact {
+    transactions: Vec<BroadcastTransaction>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BroadcastTransaction {
+    transaction_type: String,
+    contract_name: Option<String>,
+    contract_address: Option<String>,
+    hash: Option<String>,
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 4 {
+        eprintln!(
+            "Usage: {} <chain> <version> <protocol-adapter-address>",
+            args[0]
+        );
+        eprintln!(
+            "Example: {} mainnet 1.0.1 0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF",
+            args[0]
+        );
+        process::exit(1);
+    }
+
+    let chain_name = &args[1];
+    let version = &args[2];
+    let protocol_adapter_address = &args[3];
+
+    // Resolve chain ID from name.
+    let chain: NamedChain = chain_name.parse().unwrap_or_else(|_| {
+        eprintln!("Unknown chain: {chain_name}");
+        process::exit(1);
+    });
+    let chain_id: u64 = chain.into();
+
+    // Read broadcast artifact.
+    let script_name = "DeployERC20Forwarder.s.sol";
+    let contract_name = "ERC20Forwarder";
+    let artifact_path = format!("contracts/broadcast/{script_name}/{chain_id}/run-latest.json");
+
+    let artifact_json = fs::read_to_string(&artifact_path).unwrap_or_else(|_| {
+        eprintln!("Broadcast artifact not found: {artifact_path}");
+        eprintln!("Run `just contracts-deploy` first.");
+        process::exit(1);
+    });
+
+    let artifact: BroadcastArtifact = serde_json::from_str(&artifact_json).unwrap_or_else(|e| {
+        eprintln!("Failed to parse broadcast artifact: {e}");
+        process::exit(1);
+    });
+
+    // Find the CREATE/CREATE2 transaction for our contract.
+    let tx = artifact
+        .transactions
+        .iter()
+        .find(|t| {
+            matches!(t.transaction_type.as_str(), "CREATE" | "CREATE2")
+                && t.contract_name.as_deref() == Some(contract_name)
+        })
+        .unwrap_or_else(|| {
+            eprintln!("No {contract_name} deployment found in {artifact_path}");
+            process::exit(1);
+        });
+
+    let contract_address = tx.contract_address.as_ref().unwrap();
+    let tx_hash = tx.hash.clone();
+
+    // Read existing deployments.json.
+    let deployments_path = "deployments.json";
+    let mut entries: Vec<DeploymentEntry> = {
+        let json = fs::read_to_string(deployments_path).unwrap_or_else(|_| "[]".to_string());
+        serde_json::from_str(&json).unwrap_or_else(|e| {
+            eprintln!("Failed to parse {deployments_path}: {e}");
+            process::exit(1);
+        })
+    };
+
+    // Remove existing entry for this chain (if any) and add new one.
+    entries.retain(|e| e.chain_id != chain_id);
+    entries.push(DeploymentEntry {
+        network: chain_name.to_string(),
+        chain_id,
+        contract_address: contract_address.to_string(),
+        version: version.to_string(),
+        protocol_adapter_address: protocol_adapter_address.to_string(),
+        tx_hash: tx_hash.clone(),
+    });
+
+    // Sort by chain ID for deterministic output.
+    entries.sort_by_key(|e| e.chain_id);
+
+    // Write back.
+    let json = serde_json::to_string_pretty(&entries).expect("Failed to serialize deployments");
+    fs::write(deployments_path, json + "\n").expect("Failed to write deployments.json");
+
+    println!("Recorded {contract_name} deployment on {chain_name} (chain {chain_id}):");
+    println!("  address:          {contract_address}");
+    println!("  protocolAdapter:  {protocol_adapter_address}");
+    if let Some(hash) = &tx_hash {
+        println!("  tx:               {hash}");
+    }
+}

--- a/record-deployment/tests/record.rs
+++ b/record-deployment/tests/record.rs
@@ -1,0 +1,250 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Build the binary once and return its path.
+fn binary_path() -> &'static Path {
+    static PATH: std::sync::LazyLock<std::path::PathBuf> = std::sync::LazyLock::new(|| {
+        let output = Command::new(env!("CARGO"))
+            .args(["build", "-p", "record-deployment", "--message-format=short"])
+            .output()
+            .expect("Failed to build record-deployment");
+        assert!(
+            output.status.success(),
+            "cargo build failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let target_dir = std::env::var("CARGO_TARGET_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+                manifest_dir.parent().unwrap().join("target")
+            });
+        target_dir.join("debug").join("record-deployment")
+    });
+    PATH.as_path()
+}
+
+/// Minimal valid broadcast artifact for ERC20Forwarder.
+fn mock_broadcast(address: &str, tx_hash: &str) -> String {
+    format!(
+        r#"{{
+  "transactions": [
+    {{
+      "transactionType": "CREATE2",
+      "contractName": "ERC20Forwarder",
+      "contractAddress": "{address}",
+      "hash": "{tx_hash}"
+    }}
+  ]
+}}"#
+    )
+}
+
+/// Set up a temp directory mimicking the repo layout and return its path.
+fn setup_temp_dir(
+    chain_id: u64,
+    broadcast_json: Option<&str>,
+    deployments_json: Option<&str>,
+) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("Failed to create temp dir");
+
+    let deployments = deployments_json.unwrap_or("[]");
+    fs::write(tmp.path().join("deployments.json"), deployments)
+        .expect("Failed to write deployments.json");
+
+    if let Some(json) = broadcast_json {
+        let artifact_dir = tmp
+            .path()
+            .join("contracts/broadcast/DeployERC20Forwarder.s.sol")
+            .join(chain_id.to_string());
+        fs::create_dir_all(&artifact_dir).expect("Failed to create broadcast dir");
+        fs::write(artifact_dir.join("run-latest.json"), json)
+            .expect("Failed to write broadcast artifact");
+    }
+
+    tmp
+}
+
+fn run_record(tmp: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(binary_path())
+        .args(args)
+        .current_dir(tmp)
+        .output()
+        .expect("Failed to run record-deployment")
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct Entry {
+    network: String,
+    chain_id: u64,
+    contract_address: String,
+    version: String,
+    protocol_adapter_address: String,
+    tx_hash: Option<String>,
+}
+
+fn read_deployments(tmp: &Path) -> Vec<Entry> {
+    let json =
+        fs::read_to_string(tmp.join("deployments.json")).expect("Failed to read deployments.json");
+    serde_json::from_str(&json).expect("Failed to parse deployments.json")
+}
+
+const PA_ADDRESS: &str = "0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF";
+
+#[test]
+fn writes_new_entry_to_empty_deployments() {
+    let address = "0x775C81A47F2618a8594a7a7f4A3Df2a300337559";
+    let tx_hash = "0xabc123def456";
+    let broadcast = mock_broadcast(address, tx_hash);
+    let tmp = setup_temp_dir(1, Some(&broadcast), None);
+
+    let output = run_record(tmp.path(), &["mainnet", "1.0.1", PA_ADDRESS]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].network, "mainnet");
+    assert_eq!(entries[0].chain_id, 1);
+    assert_eq!(entries[0].contract_address, address);
+    assert_eq!(entries[0].version, "1.0.1");
+    assert_eq!(entries[0].protocol_adapter_address, PA_ADDRESS);
+    assert_eq!(entries[0].tx_hash.as_deref(), Some(tx_hash));
+}
+
+#[test]
+fn replaces_existing_entry_for_same_chain() {
+    let old_json = r#"[{
+        "network": "mainnet",
+        "chainId": 1,
+        "contractAddress": "0xOLD",
+        "version": "1.0.0",
+        "protocolAdapterAddress": "0xOLD_PA"
+    }]"#;
+    let new_address = "0x775C81A47F2618a8594a7a7f4A3Df2a300337559";
+    let broadcast = mock_broadcast(new_address, "0xnewhash");
+    let tmp = setup_temp_dir(1, Some(&broadcast), Some(old_json));
+
+    let output = run_record(tmp.path(), &["mainnet", "1.0.1", PA_ADDRESS]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 1, "Should have exactly one entry, not two");
+    assert_eq!(entries[0].contract_address, new_address);
+    assert_eq!(entries[0].version, "1.0.1");
+    assert_eq!(entries[0].protocol_adapter_address, PA_ADDRESS);
+}
+
+#[test]
+fn appends_without_clobbering_other_chains() {
+    let existing_json = r#"[{
+        "network": "mainnet",
+        "chainId": 1,
+        "contractAddress": "0x775C81A47F2618a8594a7a7f4A3Df2a300337559",
+        "version": "1.0.1",
+        "protocolAdapterAddress": "0x0eA3B55b68A3f307c8FE3fe66E443247c95F0CfF"
+    }]"#;
+    let new_address = "0xfAa9DE773Be11fc759A16F294d32BB2261bF818B";
+    // Chain 10 = optimism.
+    let broadcast = mock_broadcast(new_address, "0xopthash");
+    let tmp = setup_temp_dir(10, Some(&broadcast), Some(existing_json));
+
+    let output = run_record(
+        tmp.path(),
+        &[
+            "optimism",
+            "1.0.1",
+            "0x094FCC095323080e71a037b2B1e3519c07dd84F8",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 2);
+    // Mainnet (chain 1) should still be there.
+    assert_eq!(entries[0].chain_id, 1);
+    assert_eq!(
+        entries[0].contract_address,
+        "0x775C81A47F2618a8594a7a7f4A3Df2a300337559"
+    );
+    // Optimism (chain 10) should be appended.
+    assert_eq!(entries[1].chain_id, 10);
+    assert_eq!(entries[1].contract_address, new_address);
+    assert_eq!(
+        entries[1].protocol_adapter_address,
+        "0x094FCC095323080e71a037b2B1e3519c07dd84F8"
+    );
+}
+
+#[test]
+fn entries_are_sorted_by_chain_id() {
+    // Add chains in reverse order: arbitrum (42161), then mainnet (1).
+    let broadcast_arb = mock_broadcast("0xARB", "0xarbhash");
+    let tmp = setup_temp_dir(42161, Some(&broadcast_arb), None);
+
+    let output = run_record(tmp.path(), &["arbitrum", "1.0.1", PA_ADDRESS]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Now add mainnet (chain 1).
+    let broadcast_dir = tmp
+        .path()
+        .join("contracts/broadcast/DeployERC20Forwarder.s.sol/1");
+    fs::create_dir_all(&broadcast_dir).unwrap();
+    fs::write(
+        broadcast_dir.join("run-latest.json"),
+        mock_broadcast("0xMAIN", "0xmainhash"),
+    )
+    .unwrap();
+
+    let output = run_record(tmp.path(), &["mainnet", "1.0.1", PA_ADDRESS]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = read_deployments(tmp.path());
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].chain_id, 1, "Mainnet should be first (sorted)");
+    assert_eq!(
+        entries[1].chain_id, 42161,
+        "Arbitrum should be second (sorted)"
+    );
+}
+
+#[test]
+fn fails_gracefully_on_missing_artifact() {
+    // No broadcast artifact provided.
+    let tmp = setup_temp_dir(1, None, None);
+
+    let output = run_record(tmp.path(), &["mainnet", "1.0.1", PA_ADDRESS]);
+    assert!(
+        !output.status.success(),
+        "Should fail when artifact is missing"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Broadcast artifact not found"),
+        "Expected 'Broadcast artifact not found' in stderr, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Add a `record-deployment` Rust binary that reads Foundry broadcast artifacts
(e.g. `contracts/broadcast/DeployERC20Forwarder.s.sol/<chainId>/run-latest.json`)
and auto-updates `deployments.json` with the deployed contract address, tx hash,
and associated protocol adapter address.

This eliminates the need to manually copy addresses after running `just contracts-deploy`.

New just recipes:
- `just record-deployment <chain> <version> <protocol-adapter>` — extract address from broadcast artifact, update JSON, validate via bindings-build + bindings-test
- `just deploy-and-record <deployer> <token-transfer-circuit-id> <chain> <protocol-adapter> <version>` — deploy and record in one step

The binary follows the same crate pattern used in pa-evm: `publish = false`, workspace metadata, minimal deps (`alloy-chains`, `serde`, `serde_json`). Five integration tests cover new entry creation, replacement, append, sorting, and missing artifact error handling.