### PR TITLE
fix(contracts): correct etherscan and sourcify verification commands

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,3 +3,11 @@
 ## The Alchemy API key (see https://www.alchemy.com/)
 
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
+
+
+# Block Explorer Verification
+
+## The Etherscan API key (see https://etherscan.io/myapikey).
+## A single key works for all chains via Etherscan V2.
+## Required for Etherscan verification. Not needed for Sourcify.
+export ETHERSCAN_API_KEY=<ETHERSCAN_API_KEY>

--- a/.env-example
+++ b/.env-example
@@ -4,10 +4,12 @@
 
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
 
+# Remote Proving service
 
-# Block Explorer Verification
+## The URL of the remote proving service.
 
-## The Etherscan API key (see https://etherscan.io/myapikey).
-## A single key works for all chains via Etherscan V2.
-## Required for Etherscan verification. Not needed for Sourcify.
-export ETHERSCAN_API_KEY=<ETHERSCAN_API_KEY>
+export BONSAI_API_URL=<BONSAI_API_URL>
+
+## The API key for the remote proving service.
+
+export BONSAI_API_KEY=<BONSAI_API_KEY>

--- a/contracts/.env-example
+++ b/contracts/.env-example
@@ -3,9 +3,3 @@
 ## The Alchemy API key (see https://www.alchemy.com/)
 
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
-
-# Block Explorers
-
-## The Etherscan v2 API key (see https://docs.etherscan.io/etherscan-v2)
-
-export ETHERSCAN_API_KEY=<ETHERSCAN_API_KEY>

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -117,18 +117,28 @@ forge script script/DeployERC20Forwarder.s.sol:DeployERC20Forwarder \
 Append the
 
 - `--broadcast` flag to deploy to the network
-- `--verify` flag for subsequent contract verification (https://sourcify.dev/ by default, Etherscan if an `ETHERSCAN_API_KEY` environment variable is set)
+- `--verify` flag for subsequent contract verification (Sourcify by default; set `ETHERSCAN_API_KEY` to also verify on Etherscan)
+- `--slow` flag to add 15 seconds of waiting time between verification attempts
 - `--account <ACCOUNT_NAME>` flag to use a previously imported keystore (see `cast wallet --help` for more info)
 
 #### Block Explorer Verification
 
-For post-deployment verification on Etherscan run
+For post-deployment verification on **Sourcify** run
 
 ```sh
 forge verify-contract \
    <ADDRESS> \
    src/ERC20Forwarder.sol:ERC20Forwarder \
-   --chain sepolia
+   --chain sepolia \
+   --verifier sourcify
 ```
 
-after replacing `<ADDRESS>` with the respective contract address.
+For **Etherscan** (requires `ETHERSCAN_API_KEY`) run
+
+```sh
+forge verify-contract \
+   <ADDRESS> \
+   src/ERC20Forwarder.sol:ERC20Forwarder \
+   --chain sepolia \
+   --verifier etherscan
+```

--- a/justfile
+++ b/justfile
@@ -51,15 +51,15 @@ contracts-deploy deployer token-transfer-circuit-id chain protocol-adapter *args
 
 # Verify on sourcify
 contracts-verify-sourcify address chain *args:
-    cd contracts && forge verify-contract {{address}} \
+    cd contracts && env -u ETHERSCAN_API_KEY forge verify-contract {{address}} \
         src/ERC20Forwarder.sol:ERC20Forwarder \
-        --chain {{chain}} --verifier sourcify {{ args }}
+        --chain {{chain}} --verifier sourcify --watch {{ args }}
 
 # Verify on etherscan
 contracts-verify-etherscan address chain *args:
     cd contracts && forge verify-contract {{address}} \
         src/ERC20Forwarder.sol:ERC20Forwarder \
-        --chain {{chain}} --verifier etherscan {{ args }}
+        --chain {{chain}} --verifier etherscan --watch {{ args }}
 
 # Verify on both sourcify and etherscan
 contracts-verify address chain: (contracts-verify-sourcify address chain) (contracts-verify-etherscan address chain)


### PR DESCRIPTION
Work-in-progress investigation.

Closes #24

When `ETHERSCAN_API_KEY` is set, `forge verify-contract --verifier sourcify` silently reroutes to Etherscan because forge auto-populates the `-e` flag from the env var. Additionally, without an `[etherscan]` section in `foundry.toml`, forge may fail to resolve the correct explorer URL for L2 chains.

Changes:
- Strip `ETHERSCAN_API_KEY` from the `contracts-verify-sourcify` recipe environment via `env -u` so forge respects `--verifier sourcify`
- Add `[etherscan]` section to `contracts/foundry.toml` with per-chain API key config (a single Etherscan V2 key works across all chains)
- Rewrite the README verification section to document both Sourcify and Etherscan verification
- Add `ETHERSCAN_API_KEY` to `.env-example`

Upstream Foundry issues: foundry-rs/foundry#6192, foundry-rs/foundry#7466, foundry-rs/foundry#7699.