### PR TITLE
ci: pin Foundry version to v1.5.1

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
 
       - name: Show Foundry version
         run: forge --version

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
 
       - name: Install dependencies
         run: just contracts-deps


### PR DESCRIPTION
Pin Foundry to v1.5.1 in both CI workflows (contracts, bindings) so that different Foundry versions don't produce different bytecode.