### PR TITLE
feat: deploy ERC20Forwarder to Aurora and BNB

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: macos-latest
     env:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+      RPC_URL_AURORA: https://mainnet.aurora.dev
+      RPC_URL_AURORA_TESTNET: https://testnet.aurora.dev
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -14,6 +14,8 @@ jobs:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
       RPC_URL_AURORA: https://mainnet.aurora.dev
       RPC_URL_AURORA_TESTNET: https://testnet.aurora.dev
+      RPC_URL_BINANCE_SMART_CHAIN: https://bsc-dataseed.binance.org
+      RPC_URL_BINANCE_SMART_CHAIN_TESTNET: https://data-seed-prebsc-1-s1.bnbchain.org:8545
 
     steps:
       - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "anoma-pa-evm-bindings"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278c9719fa1695253cfb183b3ce41bd0520e21cbcc1d14b0a3da9ee5e5ad3992"
+checksum = "1061e45a6679239daec74bad2a959e3c35615e5369ffeea20b98967a6b484c03"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "anoma-rm-risc0"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e987cb8962ddb8e72b43a32aadfb36c2d9abe9829c91d7b97fa742b3a1b998"
+checksum = "d3d19fa05e0ecdb7bf6205e6cb31aff30b531b113f455da6eac8db3550f171b1"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.0.0"
+version = "2.1.0"
 description = "The AnomaPay ERC20 forwarder contract bindings and deployments."
 keywords.workspace = true
 authors.workspace = true

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -29,6 +29,22 @@ pub fn erc20_forwarder_deployments_map() -> HashMap<NamedChain, Address> {
             NamedChain::Arbitrum,
             address!("0xfAa9DE773Be11fc759A16F294d32BB2261bF818B"),
         ),
+        (
+            NamedChain::Aurora,
+            address!("0xA2C683FdAf51A4849D64DDeb26aBC16524Df4d00"),
+        ),
+        (
+            NamedChain::AuroraTestnet,
+            address!("0x10152C8E61506c87Eb57117FD82E754e068B2c66"),
+        ),
+        (
+            NamedChain::BinanceSmartChain,
+            address!("0xA2C683FdAf51A4849D64DDeb26aBC16524Df4d00"),
+        ),
+        (
+            NamedChain::BinanceSmartChainTestnet,
+            address!("0x24CEc6A74A0E39eE33C8356DB8655308112f587F"),
+        ),
     ])
 }
 

--- a/bindings/tests/contract.rs
+++ b/bindings/tests/contract.rs
@@ -14,18 +14,23 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn deployed_forwarders_point_to_the_current_protocol_adapter_contract() {
-    // Iterate over all supported chains
     for chain in erc20_forwarder_deployments_map().keys() {
-        let fwd_referenced_protocol_adapter: Address = fwd_instance(chain)
-            .await
+        // Skip chains not yet registered in pa-evm bindings
+        let Some(deployed_protocol_adapter) = protocol_adapter_address(chain) else {
+            eprintln!("Skipping '{chain}': no protocol adapter address in pa-evm bindings yet.");
+            continue;
+        };
+
+        let Some(fwd) = try_fwd_instance(chain).await else {
+            continue;
+        };
+
+        let fwd_referenced_protocol_adapter: Address = fwd
             .getProtocolAdapter()
             .call()
             .await
             .expect("Couldn't get protocol adapter address");
 
-        let deployed_protocol_adapter = protocol_adapter_address(chain).unwrap();
-
-        //  Check that the referenced and deployed protocol adapter addresses match.
         assert_eq!(
             fwd_referenced_protocol_adapter, deployed_protocol_adapter,
             "Protocol adapter address mismatch on network '{chain}'."
@@ -37,10 +42,18 @@ async fn deployed_forwarders_point_to_the_current_protocol_adapter_contract() {
 
 #[tokio::test]
 async fn deployed_forwarders_reference_the_expected_logic_ref() {
-    // Iterate over all supported chains
     for chain in erc20_forwarder_deployments_map().keys() {
-        let actual_logic_ref = fwd_instance(chain)
-            .await
+        // Skip chains not yet registered in pa-evm bindings
+        if protocol_adapter_address(chain).is_none() {
+            eprintln!("Skipping '{chain}': no protocol adapter address in pa-evm bindings yet.");
+            continue;
+        }
+
+        let Some(fwd) = try_fwd_instance(chain).await else {
+            continue;
+        };
+
+        let actual_logic_ref = fwd
             .getLogicRef()
             .call()
             .await
@@ -51,7 +64,6 @@ async fn deployed_forwarders_reference_the_expected_logic_ref() {
         let expected_logic_ref =
             b256!("0xbc12323668c37c3d381ca798f11116f35fb1639d12239b29da7810df3985e7ad");
 
-        // Check that the logic ref in the deployed forwarder matches the expected one from the transfer library.
         assert_eq!(
             actual_logic_ref, expected_logic_ref,
             "Logic address mismatch on network '{chain}': expected {expected_logic_ref}, actual: {actual_logic_ref}."
@@ -61,12 +73,20 @@ async fn deployed_forwarders_reference_the_expected_logic_ref() {
     }
 }
 
-async fn fwd_instance(chain: &NamedChain) -> ERC20ForwarderInstance<DynProvider> {
-    let rpc_url = alchemy_url(chain).unwrap();
+/// Tries to create an ERC20Forwarder instance for the given chain.
+/// Returns None for chains without Alchemy RPC support, logging a skip message.
+async fn try_fwd_instance(chain: &NamedChain) -> Option<ERC20ForwarderInstance<DynProvider>> {
+    let rpc_url = match alchemy_url(chain) {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("Skipping '{chain}': no Alchemy RPC URL available.");
+            return None;
+        }
+    };
 
     let provider = ProviderBuilder::new()
         .connect_anvil_with_wallet_and_config(|a| a.fork(rpc_url))
         .expect("Couldn't create anvil provider")
         .erased();
-    erc20_forwarder(&provider).await.unwrap()
+    Some(erc20_forwarder(&provider).await.unwrap())
 }

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -67,5 +67,7 @@ optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 aurora = "https://mainnet.aurora.dev"
 aurora-testnet = "https://testnet.aurora.dev"
+bnb = "https://bsc-dataseed.binance.org"
+bnb-testnet = "https://data-seed-prebsc-1-s1.bnbchain.org:8545"
 
 localhost = "http://localhost:8545"

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -65,5 +65,7 @@ base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 base-sepolia = "https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+aurora = "https://mainnet.aurora.dev"
+aurora-testnet = "https://testnet.aurora.dev"
 
 localhost = "http://localhost:8545"


### PR DESCRIPTION
Deploy ERC20Forwarder (contracts v1.0.1) to Aurora and BNB chains (testnet + mainnet). Bump bindings to v2.1.0.

Deployment details: https://gist.github.com/jonaprieto/b98637130eb3d239c48a95974b3ac497

| Network | Address |
|---------|---------|
| Aurora Testnet | `0x10152C8E61506c87Eb57117FD82E754e068B2c66` |
| Aurora Mainnet | `0xA2C683FdAf51A4849D64DDeb26aBC16524Df4d00` |
| BNB Testnet | `0x24CEc6A74A0E39eE33C8356DB8655308112f587F` |
| BNB Mainnet | `0xA2C683FdAf51A4849D64DDeb26aBC16524Df4d00` |

All contracts verified on respective explorers.