### PR TITLE
feat: add BNB RPC endpoints

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: macos-latest
     env:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+      RPC_URL_BINANCE_SMART_CHAIN_TESTNET: https://data-seed-prebsc-1-s1.bnbchain.org:8545
 
     steps:
       - name: Checkout repository

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -65,5 +65,7 @@ base = "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 base-sepolia = "https://base-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+bnb = "https://bnb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+bnb-testnet = "https://bnb-testnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 
 localhost = "http://localhost:8545"


### PR DESCRIPTION
Add BNB mainnet and testnet RPC endpoints to foundry.toml and CI env vars, preparing for ERC20Forwarder deployment on BNB.

Depends on anoma/pa-evm#479 for the ProtocolAdapter deployment addresses on BNB.