### PR TITLE
feat: add Aurora deployment addresses and RPC endpoints

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -14,6 +14,8 @@ jobs:
       ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
       RPC_URL_BINANCE_SMART_CHAIN: https://bsc-dataseed.binance.org
       RPC_URL_BINANCE_SMART_CHAIN_TESTNET: https://data-seed-prebsc-1-s1.bnbchain.org:8545
+      RPC_URL_AURORA: https://mainnet.aurora.dev
+      RPC_URL_AURORA_TESTNET: https://testnet.aurora.dev
 
     steps:
       - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.0.0"
+version = "2.1.0"
 description = "The AnomaPay ERC20 forwarder contract bindings and deployments."
 keywords.workspace = true
 authors.workspace = true

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -37,6 +37,14 @@ pub fn erc20_forwarder_deployments_map() -> HashMap<NamedChain, Address> {
             NamedChain::BinanceSmartChainTestnet,
             address!("0x3d84A760a45fEc574C6970972E98F4e613817369"),
         ),
+        (
+            NamedChain::Aurora,
+            address!("0xDe6A308ed57AF26BFf059e6C550BD4908aC1840e"),
+        ),
+        (
+            NamedChain::AuroraTestnet,
+            address!("0xdF8aE9b68932Ea8e8487570b81B27440f19C997a"),
+        ),
     ])
 }
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -67,5 +67,7 @@ optimism = "https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 optimism-sepolia = "https://opt-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
 bnb = "https://bsc-dataseed.binance.org"
 bnb-testnet = "https://data-seed-prebsc-1-s1.bnbchain.org:8545"
+aurora = "https://mainnet.aurora.dev"
+aurora-testnet = "https://testnet.aurora.dev"
 
 localhost = "http://localhost:8545"


### PR DESCRIPTION
Add ERC20Forwarder deployment addresses for Aurora mainnet and testnet, along with RPC endpoints in foundry.toml and CI environment variables.

| Network | Address |
|---------|---------|
| Aurora Mainnet | 0xDe6A308ed57AF26BFf059e6C550BD4908aC1840e |
| Aurora Testnet | 0xdF8aE9b68932Ea8e8487570b81B27440f19C997a |

Deployment details: https://gist.github.com/jonaprieto/c69e82b09ba0210b653eab689967f8d7

Split from #31 (4/5). Depends on #37, #38, and #39.