### PR TITLE
chore: bump bindings to v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.1.0"
+version = "2.2.0"
 description = "The AnomaPay ERC20 forwarder contract bindings and deployments."
 keywords.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Bump anomapay-erc20-forwarder-bindings version to 2.2.0 following the Aurora chain deployment.

Split from #31 (5/5). Depends on #37, #38, #39, and #40.