### PR TITLE
ci(contracts, bindings): justfile and workflow harmonization

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,13 +3,3 @@
 ## The Alchemy API key (see https://www.alchemy.com/)
 
 export ALCHEMY_API_KEY=<ALCHEMY_API_KEY>
-
-# Remote Proving service
-
-## The URL of the remote proving service.
-
-export BONSAI_API_URL=<BONSAI_API_URL>
-
-## The API key for the remote proving service.
-
-export BONSAI_API_KEY=<BONSAI_API_KEY>

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -43,16 +43,13 @@ jobs:
           restore-keys: rust-
 
       - name: Run rustfmt
-        run: cargo fmt -- --check
+        run: just bindings-fmt-check
 
       - name: Build Bindings
         run: just bindings-build
 
-      - name: Run clippy
-        run: cargo clippy --no-deps -- -Dwarnings
-
-      - name: Run Clippy on test
-        run: cargo clippy --no-deps  --tests -- -Dwarnings
+      - name: Lint Bindings
+        run: just bindings-lint
 
       - name: Run Tests
         run: just bindings-test

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -23,15 +23,14 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install dependencies
-        run: just contracts-deps
-
       - name: Show Foundry version
         run: forge --version
 
-      - name: Run Forge Lint
-        run: forge lint --deny warnings
-        working-directory: ./contracts
+      - name: Show Soldeer version
+        run: forge soldeer version
+
+      - name: Install dependencies
+        run: just contracts-deps
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v1
@@ -44,20 +43,8 @@ jobs:
         run: bun install solhint
         working-directory: ./contracts
 
-      - name: Run Solhint in `src`
-        run: bunx --bun solhint --config .solhint.json 'src/**/*.sol'
-        working-directory: ./contracts
-        id: solhint-src
-
-      - name: Run Solhint in `test` dir
-        run: bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
-        working-directory: ./contracts
-        id: solhint-test
-
-      - name: Run Solhint in `script` dir
-        run: bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
-        working-directory: ./contracts
-        id: solhint-script
+      - name: Run Forge Lint
+        run: just contracts-lint
 
       - name: Install Slither
         run: pip install slither-analyzer
@@ -65,15 +52,11 @@ jobs:
       - name: Show Slither version
         run: slither --version
 
-      - name: Run Slither
-        run: slither . && just contracts-clean
-        working-directory: ./contracts
-        id: slither
+      - name: Run Slither Static Analyzer
+        run: just contracts-static-analysis
 
       - name: Run Forge fmt
-        run: forge fmt --check
-        working-directory: ./contracts
-        id: fmt
+        run: just contracts-fmt-check
 
       - name: Check that bindings are up-to-date
         run: just bindings-check

--- a/contracts/.env-example
+++ b/contracts/.env-example
@@ -1,4 +1,4 @@
-# RPC Providers
+# RPC Provider
 
 ## The Alchemy API key (see https://www.alchemy.com/)
 

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -53,7 +53,7 @@ remappings_version = true
 runs = 1_000
 
 [profile.ci]
-fuzz = { runs = 1_000 }
+fuzz = { runs = 10_000 }
 verbosity = 3
 
 [rpc_endpoints]

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -53,7 +53,7 @@ remappings_version = true
 runs = 1_000
 
 [profile.ci]
-fuzz = { runs = 10_000 }
+fuzz = { runs = 1_000 }
 verbosity = 3
 
 [rpc_endpoints]

--- a/justfile
+++ b/justfile
@@ -140,6 +140,27 @@ all-build:
     @echo "==> Building bindings..."
     @just bindings-build
 
+# Lint all (contracts + bindings)
+all-lint:
+    @echo "==> Linting contracts..."
+    @just contracts-lint
+    @echo "==> Linting bindings..."
+    @just bindings-lint
+
+# Format all (contracts + bindings)
+all-fmt:
+    @echo "==> Formatting contracts..."
+    @just contracts-fmt
+    @echo "==> Formatting bindings..."
+    @just bindings-fmt
+
+# Check formatting (contracts + bindings)
+all-fmt-check:
+    @echo "==> Checking contracts formatting..."
+    @just contracts-fmt-check
+    @echo "==> Checking bindings formatting..."
+    @just bindings-fmt-check
+
 # Test all (contracts + bindings)
 all-test:
     @echo "==> Testing contracts..."

--- a/justfile
+++ b/justfile
@@ -64,6 +64,19 @@ contracts-deploy deployer token-transfer-circuit-id chain protocol-adapter *args
         --sig "run(bool,address,bytes32,address)" $IS_TEST_DEPLOYMENT {{protocol-adapter}} {{token-transfer-circuit-id}} $EMERGENCY_COMMITTEE \
          --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
 
+# Simulate deployment v2 (dry-run)
+contracts-simulate-v2 logic-ref-v2 chain protocol-adapter-v2 erc20-forwarder-v1 *args:
+    @echo "EMERGENCY_COMMITTEE: $EMERGENCY_COMMITTEE"
+    cd contracts && forge script script/DeployERC20ForwarderV2.s.sol:DeployERC20ForwarderV2 \
+        --sig "run(address,bytes32,address,address)" {{protocol-adapter-v2}} {{logic-ref-v2}} $EMERGENCY_COMMITTEE {{erc20-forwarder-v1}} \
+        --rpc-url {{chain}} {{ args }}
+
+# Deploy ERC20 forwarder v2
+contracts-deploy-v2 deployer logic-ref-v2 chain protocol-adapter-v2 erc20-forwarder-v1 *args:
+    cd contracts && forge script script/DeployERC20ForwarderV2.s.sol:DeployERC20ForwarderV2 \
+        --sig "run(address,bytes32,address,address)" {{protocol-adapter-v2}} {{logic-ref-v2}} $EMERGENCY_COMMITTEE {{erc20-forwarder-v1}} \
+        --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
+
 # Verify on sourcify
 contracts-verify-sourcify address chain *args:
     cd contracts && env -u ETHERSCAN_API_KEY forge verify-contract {{address}} \

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ contracts-simulate token-transfer-circuit-id chain protocol-adapter *args:
 contracts-deploy deployer token-transfer-circuit-id chain protocol-adapter *args:
     cd contracts && forge script script/DeployERC20Forwarder.s.sol:DeployERC20Forwarder \
         --sig "run(bool,address,bytes32,address)" $IS_TEST_DEPLOYMENT {{protocol-adapter}} {{token-transfer-circuit-id}} $EMERGENCY_COMMITTEE \
-         --broadcast --rpc-url {{chain}} {{ args }} --account {{deployer}} {{ args }}
+         --broadcast --rpc-url {{chain}} --account {{deployer}} {{ args }}
 
 # Verify on sourcify
 contracts-verify-sourcify address chain *args:

--- a/justfile
+++ b/justfile
@@ -23,6 +23,21 @@ contracts-clean:
 contracts-build *args:
     cd contracts && forge build {{ args }}
 
+# Lint contracts (forge lint + solhint)
+contracts-lint:
+    cd contracts && forge lint --deny warnings
+    cd contracts && bunx --bun solhint --config .solhint.json 'src/**/*.sol'
+    cd contracts && bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
+    cd contracts && bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
+
+# Format contracts
+contracts-fmt *args:
+    cd contracts && forge fmt {{ args }}
+
+# Check contract formatting
+contracts-fmt-check:
+    cd contracts && forge fmt --check
+
 # Run contract tests
 contracts-test *args:
     cd contracts && forge test {{ args }}
@@ -69,6 +84,19 @@ contracts-publish version *args:
     cd contracts && forge soldeer push anomapay-erc20-forwarder~{{version}} {{ args }}
 
 # --- Bindings ---
+
+# Lint bindings (clippy)
+bindings-lint:
+    cd bindings && cargo clippy --no-deps -- -Dwarnings
+    cd bindings && cargo clippy --no-deps --tests -- -Dwarnings
+
+# Format bindings
+bindings-fmt *args:
+    cd bindings && cargo fmt {{ args }}
+
+# Check bindings formatting
+bindings-fmt-check:
+    cd bindings && cargo fmt -- --check
 
 # Clean bindings
 bindings-clean:

--- a/justfile
+++ b/justfile
@@ -30,6 +30,12 @@ contracts-lint:
     cd contracts && bunx --bun solhint --config .solhint.other.json 'test/**/*.sol'
     cd contracts && bunx --bun solhint --config .solhint.other.json 'script/**/*.sol'
 
+# Run slither on contracts
+contracts-static-analysis:
+    cd contracts && slither .
+    @echo "Removing slither compilation artifacts..."
+    forge clean
+
 # Format contracts
 contracts-fmt *args:
     cd contracts && forge fmt {{ args }}
@@ -45,6 +51,7 @@ contracts-test *args:
 # Regenerate Rust bindings from contracts
 contracts-gen-bindings:
     cd contracts && forge clean && forge bind \
+        --skip test --skip script \
         --select '^(ERC20Forwarder|ERC20ForwarderV2|ERC20ForwarderV3|IProtocolAdapterSpecific|ILogicRefSpecific|IEmergencyMigratable)$' \
         --bindings-path ../bindings/src/generated/ \
         --module \
@@ -98,19 +105,6 @@ contracts-publish version *args:
 
 # --- Bindings ---
 
-# Lint bindings (clippy)
-bindings-lint:
-    cd bindings && cargo clippy --no-deps -- -Dwarnings
-    cd bindings && cargo clippy --no-deps --tests -- -Dwarnings
-
-# Format bindings
-bindings-fmt *args:
-    cd bindings && cargo fmt {{ args }}
-
-# Check bindings formatting
-bindings-fmt-check:
-    cd bindings && cargo fmt -- --check
-
 # Clean bindings
 bindings-clean:
     cd bindings && cargo clean
@@ -131,14 +125,20 @@ bindings-check: contracts-gen-bindings
 bindings-publish *args:
     cd bindings && cargo publish {{ args }}
 
-# --- All ---
+# Lint bindings (clippy)
+bindings-lint:
+    cd bindings && cargo clippy --no-deps -- -Dwarnings
+    cd bindings && cargo clippy --no-deps --tests -- -Dwarnings
 
-# Build all (contracts + bindings)
-all-build:
-    @echo "==> Building contracts..."
-    @just contracts-build
-    @echo "==> Building bindings..."
-    @just bindings-build
+# Format bindings
+bindings-fmt:
+    cargo fmt
+
+# Check bindings formatting
+bindings-fmt-check:
+    cargo fmt -- --check
+
+# --- All ---
 
 # Lint all (contracts + bindings)
 all-lint:
@@ -154,12 +154,19 @@ all-fmt:
     @echo "==> Formatting bindings..."
     @just bindings-fmt
 
-# Check formatting (contracts + bindings)
+# Check formatting for all (contracts + bindings)
 all-fmt-check:
-    @echo "==> Checking contracts formatting..."
+    @echo "==> Checking contract formatting..."
     @just contracts-fmt-check
     @echo "==> Checking bindings formatting..."
     @just bindings-fmt-check
+
+# Build all (contracts + bindings)
+all-build:
+    @echo "==> Building contracts..."
+    @just contracts-build
+    @echo "==> Building bindings..."
+    @just bindings-build
 
 # Test all (contracts + bindings)
 all-test:
@@ -168,8 +175,14 @@ all-test:
     @echo "==> Testing bindings..."
     @just bindings-test
 
-# Prerequisites check
+# Prerequisites check (mirrors CI)
 all-check:
     git status
+    @echo "==> Static analysis with slither..."
+    @just contracts-static-analysis
+    @echo "==> Checking formatting..."
+    @just all-fmt-check
+    @echo "==> Linting..."
+    @just all-lint
     @echo "==> Checking bindings are up-to-date..."
     @just bindings-check


### PR DESCRIPTION
Improvements to justfile and foundry.toml for better maintainability and local dev experience:

- Fix duplicate `{{ args }}` in contracts-deploy recipe
- Consolidate .env-example files into a single root file
- Bump CI fuzz runs to 10,000 (was identical to default at 1,000)
- Add lint/fmt recipes for contracts and bindings matching CI checks
- Add simulate/deploy recipes for ERC20ForwarderV2
- Add aggregate all-lint, all-fmt, all-fmt-check recipes
- harmonizes the workflows and justfile with the anoma/pa-evm repo (see https://github.com/anoma/pa-evm/pull/504)