### PR TITLE
fix(bindings): correct wrong bsc-testnet address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "anoma-pa-evm-bindings"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278c9719fa1695253cfb183b3ce41bd0520e21cbcc1d14b0a3da9ee5e5ad3992"
+checksum = "c1dbf0621123467e041b84774c1e4a76044dbcdba98509327afd302c4c03b9b9"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "anoma-rm-risc0"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e987cb8962ddb8e72b43a32aadfb36c2d9abe9829c91d7b97fa742b3a1b998"
+checksum = "d3d19fa05e0ecdb7bf6205e6cb31aff30b531b113f455da6eac8db3550f171b1"
 dependencies = [
  "bincode",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 [workspace.dependencies]
 alloy = { version = "1.4.0", features = ["full", "eip712", "node-bindings"] }
 alloy-chains = "0.2.27"
-anoma-pa-evm-bindings = "2.0.0"
+anoma-pa-evm-bindings = "2.1.1"
 dotenvy = { version = "0.15.7" }
 serde = { version = "1.0.228", default-features = false }
 thiserror = "2.0.17"

--- a/bindings/src/addresses.rs
+++ b/bindings/src/addresses.rs
@@ -35,7 +35,7 @@ pub fn erc20_forwarder_deployments_map() -> HashMap<NamedChain, Address> {
         ),
         (
             NamedChain::BinanceSmartChainTestnet,
-            address!("0x3d84A760a45fEc574C6970972E98F4e613817369"),
+            address!("0xDe6A308ed57AF26BFf059e6C550BD4908aC1840e"),
         ),
     ])
 }


### PR DESCRIPTION
The BSC Testnet contract was previously deployed using `IS_TEST_DEPLOYMENT=true` resulting in non-deterministic deployment.

This PR corrects this mistake and deploys the PA in line with the `RELEASE_CHECKLIST.md` procedure.

Since this relies on the pa-evm, the dependency had to be bumped as well.