### PR TITLE
chore(bindings): bump bindings version to 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anomapay-erc20-forwarder-bindings"
-version = "2.1.0"
+version = "2.1.1"
 description = "The AnomaPay ERC20 forwarder contract bindings and deployments."
 keywords.workspace = true
 authors.workspace = true


### PR DESCRIPTION
This patch corrects the wrong BSC testnet address from #38.